### PR TITLE
chore: Will now save CFN states before the stack is updated.

### DIFF
--- a/attini-action/src/main/java/attini/action/actions/cdk/CdkCommandBuilder.java
+++ b/attini-action/src/main/java/attini/action/actions/cdk/CdkCommandBuilder.java
@@ -162,6 +162,20 @@ class CdkCommandBuilder {
         return "cdk deploy --outputs-file " +
                outputFile +
                " --progress events --require-approval never" +
+               " --app cdk.out" +
+               buildExcludes +
+               notificationArns +
+               force +
+               NO_COLOR +
+               roleArn +
+               plugins +
+               stackConfig +
+               context +
+               getStacksWithAllDefault();
+    }
+
+    public String buildSynthCommand() {
+        return "cdk synth --quiet" +
                appOption +
                buildCommand +
                buildExcludes +

--- a/attini-action/src/main/java/attini/action/actions/cdk/CdkRunnerAdapter.java
+++ b/attini-action/src/main/java/attini/action/actions/cdk/CdkRunnerAdapter.java
@@ -32,11 +32,14 @@ public class CdkRunnerAdapter {
         CdkCommandBuilder cdkCommands = createCdkCommands(cdkInput.properties());
         String saveCommand = SaveCdkDataScript.getSaveScript(cdkCommands);
         String deployCommand = cdkCommands.buildDeployCommand();
+        String cdkSynthCommand = cdkCommands.buildSynthCommand();
         List<String> commands = List.of("cd " + cdkInput.properties().path(),
+                                        "echo  'Running cdk synth command: " + cdkSynthCommand + "'",
+                                        cdkSynthCommand,
+                                        saveCommand,
                                         "echo  'Running cdk deploy command: " + deployCommand + "'",
                                         deployCommand,
-                                        SaveCdkDataScript.SET_VARIABLE,
-                                        saveCommand);
+                                        SaveCdkDataScript.getFormatOutputScript(cdkCommands));
         RunnerProperties runnerProperties = new RunnerProperties(commands,
                                                                  cdkInput.properties().runner(),
                                                                  cdkInput.properties()

--- a/attini-action/src/main/java/attini/action/actions/cdk/SaveCdkDataScript.java
+++ b/attini-action/src/main/java/attini/action/actions/cdk/SaveCdkDataScript.java
@@ -2,39 +2,29 @@ package attini.action.actions.cdk;
 
 public class SaveCdkDataScript {
 
-    public static final String SET_VARIABLE = """
-                       
-            ATTINI_SAVE_CDK_STACK_ITEM="{
-              \\"resourceType\\": {
-                \\"S\\": \\"CdkStack\\"
-              },
-              \\"name\\":{
-                \\"S\\": \\"__STACK_NAME__-${ATTINI_AWS_REGION}-${ATTINI_AWS_ACCOUNT}\\"
-              },
-              \\"attiniObjectIdentifier\\": {
-                \\"S\\": \\"${ATTINI_OBJECT_IDENTIFIER}\\"
-              },
-              \\"distributionId\\":{
-                \\"S\\": \\"${ATTINI_DISTRIBUTION_ID}\\"
-              },
-              \\"distributionName\\":{
-                \\"S\\": \\"${ATTINI_DISTRIBUTION_NAME}\\"
-              },
-              \\"environment\\":{
-                \\"S\\": \\"${ATTINI_ENVIRONMENT_NAME}\\"
-              },
-              \\"stackName\\":{
-                \\"S\\": \\"__STACK_NAME__\\"
-              },
-              \\"stepName\\":{
-                \\"S\\": \\"${ATTINI_STEP_NAME}\\"
-              }
-            }"
-            """;
     private static final String SAVE = """
-            $ATTINI_RUNNER_EXEC command-mode register-cdk-stacks \
+            $ATTINI_RUNNER_EXEC command-mode save-cdk-stacks \
                        "{\
-                        \\"requestType\\":\\"register-cdk-stacks\\",\
+                        \\"requestType\\":\\"save-cdk-stacks\\",\
+                        \\"objectIdentifier\\":\\"${ATTINI_OBJECT_IDENTIFIER}\\",\
+                        \\"distributionId\\":\\"${ATTINI_DISTRIBUTION_ID}\\",\
+                        \\"distributionName\\":\\"${ATTINI_DISTRIBUTION_NAME}\\",\
+                        \\"environment\\":\\"${ATTINI_ENVIRONMENT_NAME}\\",\
+                        \\"stepName\\":\\"${ATTINI_STEP_NAME}\\",\
+                        \\"stacks\\":$(%s)\
+                        }"
+            """;
+
+    public static String getFormatOutputScript(CdkCommandBuilder commandBuilder) {
+        return FORMAT_OUTPUT.formatted(commandBuilder.buildListCommand(),
+                              commandBuilder.getOutputFile());
+
+    }
+
+    private static final String FORMAT_OUTPUT = """
+            $ATTINI_RUNNER_EXEC command-mode format-cdk-output \
+                       "{\
+                        \\"requestType\\":\\"format-cdk-stacks-output\\",\
                         \\"objectIdentifier\\":\\"${ATTINI_OBJECT_IDENTIFIER}\\",\
                         \\"distributionId\\":\\"${ATTINI_DISTRIBUTION_ID}\\",\
                         \\"distributionName\\":\\"${ATTINI_DISTRIBUTION_NAME}\\",\
@@ -46,10 +36,11 @@ public class SaveCdkDataScript {
             """;
 
     public static String getSaveScript(CdkCommandBuilder commandBuilder) {
-        return SAVE.formatted(commandBuilder.buildListCommand(),
-                              commandBuilder.getOutputFile());
+        return SAVE.formatted(commandBuilder.buildListCommand());
 
     }
+
+
 
 }
 

--- a/attini-action/src/main/java/attini/action/actions/deploycloudformation/DeployCfnCrossRegionService.java
+++ b/attini-action/src/main/java/attini/action/actions/deploycloudformation/DeployCfnCrossRegionService.java
@@ -60,8 +60,6 @@ public class DeployCfnCrossRegionService {
                 logger.info("New request for stack deletion received. Will delete stack");
                 cfnStackFacade.deleteStack(stackData);
                 resourceStateFacade.saveStackData(stackData);
-                resourceStateFacade.saveToken(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
-                                              stackData.getStackConfiguration());
                 stepFunctionFacade.sendError(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
                                              "Is in progress",
                                              "IsExecuting");
@@ -71,9 +69,9 @@ public class DeployCfnCrossRegionService {
 
             if (isNewExecution(stackData)) {
                 logger.info("New request for stack update received. Will update stack");
+                resourceStateFacade.saveStackData(stackData);
                 String stackId = cfnStackFacade.updateStackCrossRegion(stackData);
-                resourceStateFacade.saveStackData(stackData, stackId);
-                resourceStateFacade.saveToken(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
+                resourceStateFacade.saveStackId(stackId,
                                               stackData.getStackConfiguration());
                 stepFunctionFacade.sendError(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
                                              "Is in progress",
@@ -94,8 +92,6 @@ public class DeployCfnCrossRegionService {
                         logger.info("No stack found. Will create the stack");
                         String stackId = cfnStackFacade.createStackCrossRegion(stackData);
                         resourceStateFacade.saveStackData(stackData, stackId);
-                        resourceStateFacade.saveToken(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
-                                                      stackData.getStackConfiguration());
                         stepFunctionFacade.sendError(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
                                                      "Is in progress",
                                                      "IsExecuting");

--- a/attini-action/src/main/java/attini/action/actions/deploycloudformation/DeployCfnService.java
+++ b/attini-action/src/main/java/attini/action/actions/deploycloudformation/DeployCfnService.java
@@ -54,8 +54,6 @@ public class DeployCfnService {
             logger.info("Stack " + stackData.getStackConfiguration()
                                             .getStackName() + " is being deleted using callback strategy");
             resourceStateFacade.saveStackData(stackData);
-            resourceStateFacade.saveToken(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
-                                          stackData.getStackConfiguration());
 
 
         } catch (CloudFormationException e) {
@@ -76,11 +74,9 @@ public class DeployCfnService {
 
     private void deployWithCallback(StackData stackData) {
         try {
+            resourceStateFacade.saveStackData(stackData);
             String stackId = cfnStackFacade.updateCfnStack(stackData);
-            resourceStateFacade.saveStackData(stackData, stackId);
-
-            resourceStateFacade.saveToken(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
-                                          stackData.getStackConfiguration());
+            resourceStateFacade.saveStackId(stackId, stackData.getStackConfiguration());
 
         } catch (CloudFormationException e) {
             CloudFormationError cloudFormationError = resolveError(e);
@@ -113,12 +109,9 @@ public class DeployCfnService {
     private void createStack(StackData stackData) {
 
         try {
+            resourceStateFacade.saveStackData(stackData);
             String stackId = cfnStackFacade.createCfnStack(stackData);
-            resourceStateFacade.saveStackData(stackData, stackId);
-
-            resourceStateFacade.saveToken(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
-                                          stackData.getStackConfiguration());
-
+            resourceStateFacade.saveStackId(stackId, stackData.getStackConfiguration());
         } catch (AlreadyExistsException e) {
             stepFunctionFacade.sendError(stackData.getDeploymentPlanExecutionMetadata().sfnToken(),
                                          "Attini can not update stack with name=" + stackData.getStackConfiguration()

--- a/attini-action/src/main/java/attini/action/actions/runner/EcsFacade.java
+++ b/attini-action/src/main/java/attini/action/actions/runner/EcsFacade.java
@@ -38,9 +38,9 @@ public class EcsFacade {
 
     private static final Logger logger = Logger.getLogger(EcsFacade.class);
 
-    private static final String RUNNER_VERSION = "2.0.1";
+    private static final String RUNNER_VERSION = "2.0.2";
 
-    private static final String RUNNER_REQUIRED_VERSION = "2.0.1";
+    private static final String RUNNER_REQUIRED_VERSION = "2.0.2";
 
     private final EcsClient ecsClient;
     private final EnvironmentVariables environmentVariables;

--- a/attini-action/src/main/java/attini/action/facades/stackdata/ResourceStateFacade.java
+++ b/attini-action/src/main/java/attini/action/facades/stackdata/ResourceStateFacade.java
@@ -34,7 +34,7 @@ public interface ResourceStateFacade {
 
     Optional<SfnExecutionArn> getStacksSfnExecutionArn(StackConfiguration stackConfiguration);
 
-    void saveToken(String sfnToken, StackConfiguration stackConfiguration);
+    void saveStackId(String stackId, StackConfiguration stackConfiguration);
 
     Optional<StackTemplate> getStackTemplate(StackConfiguration stackConfiguration);
 }

--- a/attini-action/src/test/java/attini/action/actions/cdk/CdkCommandBuilderTest.java
+++ b/attini-action/src/test/java/attini/action/actions/cdk/CdkCommandBuilderTest.java
@@ -19,22 +19,29 @@ class CdkCommandBuilderTest {
     @Test
     void ShouldCreateDeployCommand() {
         String commandString = CdkCommandBuilder.builder(null, OUTPUT_FILE).buildDeployCommand();
-        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --no-color --all", commandString);
+        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color --all", commandString);
     }
+
+    @Test
+    void ShouldCreateSynthCommand() {
+        String commandString = CdkCommandBuilder.builder(null, OUTPUT_FILE).buildSynthCommand();
+        assertEquals("cdk synth --quiet --no-color --all", commandString);
+    }
+
 
     @Test
     void ShouldCreateDeployAndListCommand_shouldAddApps() {
         CdkCommandBuilder builder = CdkCommandBuilder.builder(List.of("test1", "test2"), OUTPUT_FILE);
-        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --no-color test1 test2", builder.buildDeployCommand());
+        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color test1 test2", builder.buildDeployCommand());
         assertEquals("cdk ls --long --json --no-color --app cdk.out test1 test2", builder.buildListCommand());
 
     }
 
     @Test
-    void ShouldCreateDeployCommand_shouldAddBuild() {
+    void ShouldCreateSynthCommand_shouldAddBuild() {
 
-        String commandString = CdkCommandBuilder.builder(null, OUTPUT_FILE).addBuild("npm install").buildDeployCommand();
-        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --build \"npm install\" --no-color --all", commandString);
+        String commandString = CdkCommandBuilder.builder(null, OUTPUT_FILE).addBuild("npm install").buildSynthCommand();
+        assertEquals("cdk synth --quiet --build \"npm install\" --no-color --all", commandString);
     }
 
 
@@ -49,7 +56,7 @@ class CdkCommandBuilderTest {
                                                 .addStackConfig(stackConfiguration)
                                                 .buildDeployCommand();
         assertEquals(
-                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --no-color --parameters MyStack:MyParam=MyParamValue --parameters MyStack:MySecondParam=MySecondParamValue --all",
+                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color --parameters MyStack:MyParam=MyParamValue --parameters MyStack:MySecondParam=MySecondParamValue --all",
                 commandString);
     }
 
@@ -64,7 +71,7 @@ class CdkCommandBuilderTest {
                                                 .addStackConfig(stackConfiguration)
                                                 .buildDeployCommand();
         assertEquals(
-                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --no-color --parameters MyParam=MyParamValue --parameters MySecondParam=MySecondParamValue --all",
+                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color --parameters MyParam=MyParamValue --parameters MySecondParam=MySecondParamValue --all",
                 commandString);
     }
 
@@ -88,7 +95,7 @@ class CdkCommandBuilderTest {
         String commandString = CdkCommandBuilder.builder(null, OUTPUT_FILE)
                                                 .addContext(context)
                                                 .buildDeployCommand();
-        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --no-color --context key1=value1 --context key2=value2 --all",
+        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color --context key1=value1 --context key2=value2 --all",
                      commandString);
     }
 
@@ -98,7 +105,7 @@ class CdkCommandBuilderTest {
         String commandString = CdkCommandBuilder.builder(null, OUTPUT_FILE)
                                                 .addApp("AppName")
                                                 .buildDeployCommand();
-        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app AppName --no-color --all", commandString);
+        assertEquals("cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color --all", commandString);
     }
 
     @Test
@@ -115,7 +122,7 @@ class CdkCommandBuilderTest {
                                                 .addPlugins(List.of("plugin1", "plugin2"))
                                                 .buildDeployCommand();
         assertEquals(
-                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app AppName --no-color --plugin plugin1 --plugin plugin2 --all",
+                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color --plugin plugin1 --plugin plugin2 --all",
                 commandString);
     }
 
@@ -127,7 +134,7 @@ class CdkCommandBuilderTest {
                                                                .addBuildExclude(List.of("exclude1", "exclude2"));
 
         assertEquals(
-                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app AppName --build-exclude exclude1 --build-exclude exclude2 --no-color --all",
+                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --build-exclude exclude1 --build-exclude exclude2 --no-color --all",
                 commandsBuilder
                         .buildDeployCommand());
 
@@ -145,7 +152,7 @@ class CdkCommandBuilderTest {
                                                              .addNotificationArns(List.of("arn1", "arn2"));
 
         assertEquals(
-                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app AppName --notification-arns arn1 --notification-arns arn2 --no-color --all",
+                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --notification-arns arn1 --notification-arns arn2 --no-color --all",
                 commandsBuilder
                         .buildDeployCommand());
 
@@ -163,7 +170,7 @@ class CdkCommandBuilderTest {
                                                              .addForce(true);
 
         assertEquals(
-                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app AppName --force --no-color --all",
+                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --force --no-color --all",
                 commandsBuilder
                         .buildDeployCommand());
 
@@ -181,7 +188,7 @@ class CdkCommandBuilderTest {
                                                              .addRoleArn("some-arn");
 
         assertEquals(
-                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app AppName --no-color --role-arn some-arn --all",
+                "cdk deploy --outputs-file "+OUTPUT_FILE+" --progress events --require-approval never --app cdk.out --no-color --role-arn some-arn --all",
                 commandsBuilder
                         .buildDeployCommand());
 

--- a/template.yaml
+++ b/template.yaml
@@ -338,7 +338,7 @@ Mappings:
       AttiniStepGuardFunction: 40
   Variables:
     Runner:
-      Image: public.ecr.aws/attini/default-runner:attini-default-runner-2.0.1
+      Image: public.ecr.aws/attini/default-runner:attini-default-runner-2.0.2
 
 
 Resources:


### PR DESCRIPTION
chore: Will now save CFN states before the stack is updated. This is to make the data available to custom resources in the stack being updated. This is true for the CFN step and the CDK step.